### PR TITLE
Add reference to codemirror.css so editor works

### DIFF
--- a/flex-directory.php
+++ b/flex-directory.php
@@ -155,6 +155,7 @@ class FlexDirectoryPlugin extends Plugin
 
             // CSS / JS Assets
             $this->grav['assets']->addCss('plugin://flex-directory/css/admin.css');
+            $this->grav['assets']->addCss('plugin://admin/themes/grav/css/codemirror/codemirror.css');
 
             if ($this->controller->getTarget() == 'entries' && $this->controller->getAction() == 'list') {
                 $this->grav['assets']->addCss('plugin://flex-directory/css/filter.formatter.css');


### PR DESCRIPTION
This seems to fix the formatting problem with editor field type in flex-directory - was missing the reference to codemirror.css. Hope this works. 